### PR TITLE
Fix Travis tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,6 @@ language: node_js
 node_js:
   - "6"
 script:
+  # this is a condensed version of the default PATH that puts ./node_modules/.bin at the end
+  - export PATH=/usr/bin:/home/travis/.nvm/versions/node/v6.4.0/bin:/home/travis/bin:/home/travis/.local/bin:/usr/local/phantomjs/bin:/usr/local/clang-3.4/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin:./node_modules/.bin
   - make travis-ci

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "An ECMAScript implementation of a Membrane, allowing users to dynamically hide, override, or extend objects in JavaScript with controlled effects on the original objects.",
   "main": "dist/node/Membrane.js",
   "scripts": {
-    "test": "./node_modules/jasmine/bin/jasmine.js"
+    "test": "jasmine"
   },
   "repository": {
     "type": "git",

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "An ECMAScript implementation of a Membrane, allowing users to dynamically hide, override, or extend objects in JavaScript with controlled effects on the original objects.",
   "main": "dist/node/Membrane.js",
   "scripts": {
-    "test": "jasmine"
+    "test": "./node_modules/jasmine/bin/jasmine.js"
   },
   "repository": {
     "type": "git",


### PR DESCRIPTION
Turns out that some module had installed it's own `make` utility, and travis puts the `./node_modules/bin` folder ahead of `/usr/bin` in their PATH, so it got loaded by default.

When I spit out the PATH ([log](https://travis-ci.org/hawkrives/es7-membrane/builds/154404786#L301)), they had made some other travis-specific changes as well, so I opted for editing the PATH here to remove duplicates and leave the order almost the same. I just demoted node_modules to the _end_ of the PATH.

If you'd prefer to just edit the path by prepending `/usr/bin` instead, I can do that.